### PR TITLE
feat: added hamburger menu for mobile responsiveness

### DIFF
--- a/about.html
+++ b/about.html
@@ -8,6 +8,13 @@
 
 <header class="top-header">
     <div class="logo">🐂 Trade Bull</div>
+
+    <button class="hamburger" aria-label="Toggle menu" aria-expanded="false">
+        <span></span>
+        <span></span>
+        <span></span>
+    </button>
+
     <nav class="nav-links">
         <a href="index.html">Home</a>
         <a href="about.html">About Us</a>
@@ -29,6 +36,6 @@
         rather than fake profit screenshots.
     </p>
 </main>
-
+<script src="js/main.js"></script>
 </body>
 </html>

--- a/contact.html
+++ b/contact.html
@@ -8,6 +8,13 @@
 
 <header class="top-header">
     <div class="logo">🐂 Trade bull</div>
+
+    <button class="hamburger" aria-label="Toggle menu" aria-expanded="false">
+        <span></span>
+        <span></span>
+        <span></span>
+    </button>
+
     <nav class="nav-links">
         <a href="index.html">Home</a>
         <a href="about.html">About Us</a>
@@ -23,6 +30,6 @@
     <p>Telegram: @mallubull</p>
     <p>Instagram: @mallubull</p>
 </main>
-
+<script src="js/main.js"></script>
 </body>
 </html>

--- a/css/style.css
+++ b/css/style.css
@@ -130,9 +130,117 @@ footer {
     box-shadow: 0 4px 10px rgba(34,197,94,0.12);
 }
 
+/* Hamburger Menu Button */
+.hamburger {
+    display: none;
+    flex-direction: column;
+    gap: 5px;
+    background: none;
+    border: none;
+    cursor: pointer;
+    padding: 8px;
+    z-index: 1001;
+}
+
+.hamburger span {
+    width: 25px;
+    height: 3px;
+    background: #22c55e;
+    border-radius: 2px;
+    transition: all 0.3s ease;
+}
+
+/* Hamburger animation when active */
+.hamburger.active span:nth-child(1) {
+    transform: rotate(45deg) translate(7px, 7px);
+}
+
+.hamburger.active span:nth-child(2) {
+    opacity: 0;
+}
+
+.hamburger.active span:nth-child(3) {
+    transform: rotate(-45deg) translate(7px, -7px);
+}
+
 /* Mobile Menu */
 @media (max-width: 768px) {
-    .nav-links {
-        display: none; /* later we add hamburger menu */
+    .top-header {
+        padding: 18px 20px;
     }
+
+    .hamburger {
+        display: flex;
+    }
+
+    /* Reset and hide nav-links by default on mobile */
+    .nav-links {
+        position: fixed;
+        top: 0;
+        right: -100%;
+        height: 100vh;
+        width: 70%;
+        max-width: 300px;
+        background: #020617;
+        transition: right 0.3s ease;
+        z-index: 1000;
+        box-shadow: -2px 0 10px rgba(0,0,0,0.5);
+        padding: 80px 20px 20px;
+        overflow-y: auto;
+        display: block;
+    }
+
+    .nav-links.active {
+        right: 0;
+    }
+
+    /* For pages with ul/li structure (index.html) */
+    .nav-links ul {
+        display: flex;
+        flex-direction: column;
+        gap: 0;
+        padding: 0;
+        width: 100%;
+    }
+
+    .nav-links li {
+        width: 100%;
+    }
+
+    /* For pages with direct <a> tags - make them stack vertically */
+    .nav-links > a {
+        display: block;
+        width: 100%;
+        margin-bottom: 0;
+    }
+
+    /* All links should be full width and stacked */
+    .nav-links a {
+        display: block;
+        padding: 15px 20px;
+        border-radius: 8px;
+        width: 100%;
+        box-sizing: border-box;
+    }
+
+    .signup-btn {
+        margin-top: 10px;
+        text-align: center;
+    }
+}
+
+/* Skip link for accessibility */
+.skip-link {
+    position: absolute;
+    top: -40px;
+    left: 0;
+    background: #22c55e;
+    color: #020617;
+    padding: 8px;
+    text-decoration: none;
+    z-index: 100;
+}
+
+.skip-link:focus {
+    top: 0;
 }

--- a/index.html
+++ b/index.html
@@ -21,6 +21,12 @@
 <header class="top-header" role="banner">
     <h1 class="site-title"><a href="index.html" class="logo" aria-label="Trade Bull home"><span aria-hidden="true">🐂</span> Trade Bull</a></h1>
 
+    <button class="hamburger" aria-label="Toggle menu" aria-expanded="false">
+        <span></span>
+        <span></span>
+        <span></span>
+    </button>
+
     <nav class="nav-links" aria-label="Main navigation">
         <ul>
             <li><a href="index.html" aria-current="page">Home</a></li>

--- a/js/main.js
+++ b/js/main.js
@@ -49,3 +49,37 @@ function formatCurrency(amount) {
     // Placeholder: expects a pre-formatted string like "+₹1,234". Implement parsing if needed.
     return amount;
 }
+
+// Hamburger Menu Toggle
+const hamburger = document.querySelector('.hamburger');
+const navLinks = document.querySelector('.nav-links');
+
+if (hamburger && navLinks) {
+    // Toggle menu on hamburger click
+    hamburger.addEventListener('click', () => {
+        const isActive = navLinks.classList.toggle('active');
+        hamburger.classList.toggle('active');
+        hamburger.setAttribute('aria-expanded', isActive);
+    });
+
+    // Close menu when clicking on any link
+    const menuLinks = navLinks.querySelectorAll('a');
+    menuLinks.forEach(link => {
+        link.addEventListener('click', () => {
+            navLinks.classList.remove('active');
+            hamburger.classList.remove('active');
+            hamburger.setAttribute('aria-expanded', 'false');
+        });
+    });
+
+    // Close menu when clicking outside
+    document.addEventListener('click', (e) => {
+        if (!hamburger.contains(e.target) && !navLinks.contains(e.target)) {
+            if (navLinks.classList.contains('active')) {
+                navLinks.classList.remove('active');
+                hamburger.classList.remove('active');
+                hamburger.setAttribute('aria-expanded', 'false');
+            }
+        }
+    });
+}


### PR DESCRIPTION
### **Summary:**
Added a hamburger menu toggle for mobile navigation on screens below `768px` width.

### **Changes made:**
- Added hamburger button component with animated icon (three bars → X)
- Implemented slide-in navigation menu from the right side on mobile
- Updated CSS with mobile-specific styles using media queries
- Applied changes across pages (`index.html`, `about.html`, `contact.html`)

### **Behavior:**
- **Mobile** (<` 768px`): Hamburger icon appears, navigation hidden by default
- **Desktop** (≥ `768px`): Standard horizontal navigation, hamburger hidden

Menu closes when:
- Clicking any navigation link
- Clicking outside the menu
- Clicking the hamburger icon again

### Files Modified:
- `index.html` - Added hamburger button to header
- `about.html` - Added hamburger button to header
- `contact.html` - Added hamburger button to header
- `css/style.css` - Added hamburger and mobile menu styles
- `js/main.js` - Implemented menu toggle logic

### Screenshots:
<img width="330" height="564" alt="Screenshot 2025-12-30 112407" src="https://github.com/user-attachments/assets/9ff70fc4-bde5-434b-8b82-6f770aee33ac" />
<img width="350" height="564" alt="Screenshot 2025-12-30 112424" src="https://github.com/user-attachments/assets/02f47fb4-ef07-4397-ac0f-60fbfc1eb9af" />
<img width="364" height="562" alt="Screenshot 2025-12-30 112438" src="https://github.com/user-attachments/assets/2020fc3f-0797-4bf5-96bf-b3773df029fb" />
<img width="365" height="564" alt="Screenshot 2025-12-30 112550" src="https://github.com/user-attachments/assets/4c3eea63-07bf-454d-9da9-d172d9be75db" />
<img width="366" height="564" alt="Screenshot 2025-12-30 112604" src="https://github.com/user-attachments/assets/e2192a95-3cf3-4ffc-a610-233d6ff4fb4e" />
<img width="363" height="562" alt="Screenshot 2025-12-30 112612" src="https://github.com/user-attachments/assets/a0aa1d71-1bee-4f66-993e-3901a528f7a0" />
